### PR TITLE
Stop editing mobile package.json

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -254,9 +254,6 @@ meta_set "build-step" "install-dependencies"
 log_build_scripts "$BUILD_DIR"
 run_prebuild_script "$BUILD_DIR" | output "$LOG_FILE"
 
-header "Clearing mobile workspace dependencies"
-echo '{"name": "@consider/mobile","private": true,"version": "1.0.0","dependencies": {},"devDependencies": {}}' > mobile/package.json
-
 header "Clearing symlinked eslint-config node modules"
 rm node_modules
 


### PR DESCRIPTION
This breaks standalone groups build, and I believe is no longer required for main either - we don't use yarn workspaces any more.